### PR TITLE
Migrated database.py to class, get function now returns Database object

### DIFF
--- a/chiya.py
+++ b/chiya.py
@@ -52,7 +52,7 @@ async def on_message(message: discord.Message):
 
 if __name__ == '__main__':
     # Attempt to create the db, tables, and columns for Chiya.
-    utils.database.setup_db()
+    utils.database.Database().setup()
 
     # Recursively loads in all the cogs in the folder named cogs.
     # Skips over any cogs that start with '__' or do not end with .py.

--- a/cogs/commands/moderation/bans.py
+++ b/cogs/commands/moderation/bans.py
@@ -2,7 +2,6 @@ import datetime
 import logging
 import time
 
-import dataset
 import discord
 from discord.ext import commands
 from discord.ext.commands import Cog, Bot
@@ -33,7 +32,7 @@ class BanCog(Cog):
         await ctx.guild.ban(user=user, reason=reason, delete_message_days=delete_message_days)
 
         # Open a connection to the database.
-        db = dataset.connect(database.get_db())
+        db = database.Database().get()
 
         # Add the ban to the mod_log database.
         db["mod_logs"].insert(dict(
@@ -67,7 +66,7 @@ class BanCog(Cog):
             return
 
         # Open a connection to the database.
-        db = dataset.connect(database.get_db())
+        db = database.Database().get()
 
         # Add the unban to the mod_log database.
         db["mod_logs"].insert(dict(

--- a/cogs/commands/moderation/kicks.py
+++ b/cogs/commands/moderation/kicks.py
@@ -1,7 +1,6 @@
 import logging
 import time
 
-import dataset
 import discord
 from discord.ext import commands
 from discord.ext.commands import Cog, Bot
@@ -107,7 +106,7 @@ class KickCog(Cog):
         await ctx.guild.kick(user=member, reason=reason)
 
         # Open a connection to the database.
-        db = dataset.connect(database.get_db())
+        db = database.Database().get()
 
         # Add the kick to the mod_log database.
         db["mod_logs"].insert(dict(

--- a/cogs/commands/moderation/mutes.py
+++ b/cogs/commands/moderation/mutes.py
@@ -2,7 +2,6 @@ import datetime
 import logging
 import time
 
-import dataset
 import discord
 import privatebinapi
 from discord.ext import commands
@@ -34,7 +33,7 @@ class MuteCog(Cog):
         await member.add_roles(role, reason=reason)
 
         # Open a connection to the database.
-        db = dataset.connect(database.get_db())
+        db = database.Database().get()
 
         # Add the mute to the mod_log database.
         db["mod_logs"].insert(dict(
@@ -66,7 +65,7 @@ class MuteCog(Cog):
         await member.remove_roles(role, reason=reason)
 
         # Open a connection to the database.
-        db = dataset.connect(database.get_db())
+        db = database.Database().get()
 
         # Add the unmute to the mod_log database.
         db["mod_logs"].insert(dict(
@@ -175,7 +174,7 @@ class MuteCog(Cog):
         mute_channel = discord.utils.get(category.channels, name=f"mute-{user_id}")
 
         # Open a connection to the database.
-        db = dataset.connect(database.get_db())
+        db = database.Database().get()
 
         #  TODO: Get the mute reason by looking up the latest mute for the user and getting the reason column data.
         table = db["mod_logs"]

--- a/cogs/commands/moderation/notes.py
+++ b/cogs/commands/moderation/notes.py
@@ -3,7 +3,6 @@ import datetime
 import logging
 import time
 
-import dataset
 import discord
 from discord.embeds import Embed
 from discord.ext import commands
@@ -64,7 +63,7 @@ class NotesCog(Cog):
             user = await self.bot.fetch_user(user)
 
         # Open a connection to the database.
-        db = dataset.connect(database.get_db())
+        db = database.Database().get()
 
         # Add the note to the mod_logs database.
         note_id = db["mod_logs"].insert(dict(
@@ -121,7 +120,7 @@ class NotesCog(Cog):
             user = await self.bot.fetch_user(user)
 
         # Open a connection to the database.
-        db = dataset.connect(database.get_db())
+        db = database.Database().get()
 
         # Querying DB for the list of actions matching the filter criteria (if mentioned).
         mod_logs = db["mod_logs"]
@@ -314,7 +313,7 @@ class NotesCog(Cog):
         await ctx.defer()
 
         # Open a connection to the database.
-        db = dataset.connect(database.get_db())
+        db = database.Database().get()
 
         table = db["mod_logs"]
 

--- a/cogs/commands/moderation/restricts.py
+++ b/cogs/commands/moderation/restricts.py
@@ -2,7 +2,6 @@ import datetime
 import logging
 import time
 
-import dataset
 import discord
 from discord.ext import commands
 from discord.ext.commands import Cog, Bot
@@ -39,7 +38,7 @@ class RestrictCog(Cog):
         await member.add_roles(role, reason=reason)
 
         # Open a connection to the database.
-        db = dataset.connect(database.get_db())
+        db = database.Database().get()
 
         # Add the restrict to the mod_log database.
         db["mod_logs"].insert(dict(
@@ -70,7 +69,7 @@ class RestrictCog(Cog):
         await member.remove_roles(role, reason=reason)
 
         # Open a connection to the database.
-        db = dataset.connect(database.get_db())
+        db = database.Database().get()
 
         # Add the unrestrict to the mod_log database.
         db["mod_logs"].insert(dict(

--- a/cogs/commands/moderation/tickets.py
+++ b/cogs/commands/moderation/tickets.py
@@ -1,8 +1,6 @@
 import logging
-import re
 import time
 
-import dataset
 import discord
 import privatebinapi
 from discord.ext import commands
@@ -102,7 +100,7 @@ class TicketCog(Cog):
         await channel.send(embed=embed)
 
         # Open a connection to the database.
-        db = dataset.connect(database.get_db())
+        db = database.Database().get()
 
         # Insert a pending ticket into the database.
         db["tickets"].insert(
@@ -169,7 +167,7 @@ class TicketCog(Cog):
             return
 
         # Open a connection to the database.
-        db = dataset.connect(database.get_db())
+        db = database.Database().get()
 
         # Get the ticket in the database.
         table = db["tickets"]

--- a/cogs/commands/moderation/warns.py
+++ b/cogs/commands/moderation/warns.py
@@ -1,7 +1,6 @@
 import logging
 import time
 
-import dataset
 import discord
 from discord.ext import commands
 from discord.ext.commands import Cog, Bot
@@ -92,7 +91,7 @@ class WarnsCog(Cog):
             embed.add_field(name="Notice:", value=f"Unable to message {member.mention} about this action. This can be caused by the user not being in the server, having DMs disabled, or having the bot blocked.")
 
         # Open a connection to the database.
-        db = dataset.connect(database.get_db())
+        db = database.Database().get()
 
         # Add the warning to the mod_log database.
         db["mod_logs"].insert(dict(

--- a/cogs/commands/reminder.py
+++ b/cogs/commands/reminder.py
@@ -1,7 +1,6 @@
 import logging
 from datetime import datetime
 
-import dataset
 from discord.ext import commands
 from discord.ext.commands import Bot, Cog
 from discord_slash import cog_ext, SlashContext
@@ -55,7 +54,7 @@ class Reminder(Cog):
             return
 
         # Open a connection to the database.
-        db = dataset.connect(database.get_db())
+        db = database.Database().get()
 
         remind_id = db["remind_me"].insert(dict(
             reminder_location=ctx.channel.id,
@@ -105,7 +104,7 @@ class Reminder(Cog):
         await ctx.defer()
 
         # Open a connection to the database.
-        db = dataset.connect(database.get_db())
+        db = database.Database().get()
 
         remind_me = db["remind_me"]
         reminder = remind_me.find_one(id=reminder_id)
@@ -149,7 +148,7 @@ class Reminder(Cog):
         await ctx.defer()
 
         # Open a connection to the database.
-        db = dataset.connect(database.get_db())
+        db = database.Database().get()
 
         # Find all reminders from user and haven't been sent.
         remind_me = db["remind_me"]
@@ -199,7 +198,7 @@ class Reminder(Cog):
         await ctx.defer()
 
         # Open a connection to the database.
-        db = dataset.connect(database.get_db())
+        db = database.Database().get()
 
         # Find all reminders from user and haven't been sent.
         table = db["remind_me"]
@@ -247,7 +246,7 @@ class Reminder(Cog):
         await ctx.defer()
 
         # Open a connection to the database.
-        db = dataset.connect(database.get_db())
+        db = database.Database().get()
 
         remind_me = db["remind_me"]
         result = remind_me.find(author_id=ctx.author.id, sent=False)

--- a/cogs/commands/settings.py
+++ b/cogs/commands/settings.py
@@ -1,6 +1,5 @@
 import logging
 
-import dataset
 from discord.ext.commands import Bot, Cog
 from discord_slash import cog_ext, SlashContext
 from discord_slash.model import SlashCommandPermissionType
@@ -8,14 +7,13 @@ from discord_slash.utils.manage_commands import create_option, create_permission
 
 from utils import database
 from utils import embeds
-from utils.database import get_db
 
 log = logging.getLogger(__name__)
 
 
 def get_value(config: str):
     # Open a connection to the database.
-    db = dataset.connect(get_db())
+    db = database.Database().get()
 
     # Find a result that matches the name from the parameter.
     settings = db["settings"]
@@ -71,7 +69,7 @@ class Settings(Cog):
     )
     async def add(self, ctx: SlashContext, name: str, value: str, censored: bool):
         # Open a connection to the database.
-        db = dataset.connect(database.get_db())
+        db = database.Database().get()
         table = db["settings"]
         result = table.find_one(name=name)
 
@@ -137,7 +135,7 @@ class Settings(Cog):
         await ctx.defer()
 
         # Open a connection to the database.
-        db = dataset.connect(database.get_db())
+        db = database.Database().get()
         table = db["settings"]
         result = table.find_one(name=name)
 
@@ -185,7 +183,7 @@ class Settings(Cog):
     )
     async def delete(self, ctx: SlashContext, name: str):
         # Open a connection to the database.
-        db = dataset.connect(database.get_db())
+        db = database.Database().get()
         table = db["settings"]
         result = table.find_one(name=name)
 
@@ -220,7 +218,7 @@ class Settings(Cog):
     )
     async def list(self, ctx: SlashContext):
         # Open a connection to the database.
-        db = dataset.connect(database.get_db())
+        db = database.Database().get()
         table = db["settings"]
         settings = table.all()
 
@@ -265,7 +263,7 @@ class Settings(Cog):
     )
     async def view(self, ctx: SlashContext, name: str):
         # Open a connection to the database.
-        db = dataset.connect(database.get_db())
+        db = database.Database().get()
         table = db["settings"]
         result = table.find_one(name=name)
 

--- a/cogs/listeners/bans_handle.py
+++ b/cogs/listeners/bans_handle.py
@@ -2,7 +2,6 @@ import logging
 import time
 from typing import Union
 
-import dataset
 import discord
 from discord import User, Member, Guild
 from discord.ext import commands
@@ -20,7 +19,7 @@ class BansHandler(commands.Cog):
     @commands.Cog.listener()
     async def on_member_ban(self, guild: Guild, user: Union[User, Member]):
         # Open a connection to the database.
-        db = dataset.connect(database.get_db())
+        db = database.Database().get()
 
         # Get the ban entry of the user who just got banned.
         ban_entry = await guild.fetch_ban(user)

--- a/cogs/listeners/mutes_handle.py
+++ b/cogs/listeners/mutes_handle.py
@@ -1,7 +1,6 @@
 import logging
 import time
 
-import dataset
 import discord
 from discord import Member
 from discord.ext import commands
@@ -22,7 +21,7 @@ class MutesHandler(commands.Cog):
     @commands.Cog.listener()
     async def on_member_remove(self, member: Member) -> None:
         # Open a connection to the database.
-        db = dataset.connect(database.get_db())
+        db = database.Database().get()
 
         guild = member.guild
         mute_channel = discord.utils.get(guild.channels, name=f"mute-{member.id}")

--- a/cogs/listeners/restricts_handle.py
+++ b/cogs/listeners/restricts_handle.py
@@ -1,6 +1,5 @@
 import logging
 
-import dataset
 import discord
 from discord import Member, Message
 from discord.ext import commands
@@ -21,7 +20,7 @@ class RestrictsHandler(commands.Cog):
     @commands.Cog.listener()
     async def on_member_join(self, member: Member):
         # Open a connection to the database.
-        db = dataset.connect(database.get_db())
+        db = database.Database().get()
 
         # Get the "Restricted" role.
         role_restricted = discord.utils.get(member.guild.roles, id=settings.get_value("role_restricted"))

--- a/cogs/tasks/reminders.py
+++ b/cogs/tasks/reminders.py
@@ -1,7 +1,6 @@
 import logging
 from datetime import datetime, timezone
 
-import dataset
 import discord
 from discord.ext import tasks
 from discord.ext.commands import Bot, Cog
@@ -30,7 +29,7 @@ class ReminderTask(Cog):
         current_time = datetime.now(tz=timezone.utc).timestamp()
 
         # Open a connection to the database.
-        db = dataset.connect(database.get_db())
+        db = database.Database().get()
 
         # Find all reminders that are older than current time and have not been sent yet.
         remind_me = db["remind_me"]

--- a/cogs/tasks/timed_mod_actions.py
+++ b/cogs/tasks/timed_mod_actions.py
@@ -1,7 +1,6 @@
 import logging
 from datetime import datetime, timezone
 
-import dataset
 from discord.ext import tasks
 from discord.ext.commands import Bot, Cog
 
@@ -28,7 +27,7 @@ class TimedModActionsTask(Cog):
         await self.bot.wait_until_ready()
 
         # Open a connection to the database.
-        db = dataset.connect(database.get_db())
+        db = database.Database().get()
 
         # Query the database for all temporary mod actions that haven't executed yet.
         results = db["timed_mod_actions"].find(

--- a/utils/database.py
+++ b/utils/database.py
@@ -7,71 +7,78 @@ from sqlalchemy_utils import database_exists, create_database
 
 log = logging.getLogger(__name__)
 
+class Database:
+    def __init__(self) -> None:
+        self.HOST = os.getenv("MYSQL_HOST")
+        self.DB = os.getenv("MYSQL_DATABASE")
+        self.USER = os.getenv("MYSQL_USER")
+        self.PASSWORD = os.getenv("MYSQL_PASSWORD")
 
-def get_db():
-    """ Returns the OS friendly path to the SQLite database. """
-    HOST = os.getenv("MYSQL_HOST")
-    DATABASE = os.getenv("MYSQL_DATABASE")
-    USER = os.getenv("MYSQL_USER")
-    PASSWORD = os.getenv("MYSQL_PASSWORD")
-    return f"mysql://{USER}:{PASSWORD}@{HOST}/{DATABASE}"
+    def url(self) -> str:
+        """ Returns the database URL as a string. """
+        return f"mysql://{self.USER}:{self.PASSWORD}@{self.HOST}/{self.DB}"
 
+    def get(self) -> dataset.Database:
+        """ Returns the dataset database object. """
+        return dataset.connect(
+            url=f"mysql://{self.USER}:{self.PASSWORD}@{self.HOST}/{self.DB}"
+        )
 
-def setup_db():
-    """ Sets up the tables needed for Chiya. """
-    # Create the database if it doesn't already exist.
-    engine = create_engine(get_db())
-    if not database_exists(engine.url):
-        create_database(engine.url)
+    def setup(self) -> None:
+        """ Sets up the tables needed for Chiya. """
+        # Create the database if it doesn't already exist.
+        engine = create_engine(self.url())
+        if not database_exists(engine.url):
+            create_database(engine.url)
 
-    # Open a connection to the database.
-    db = dataset.connect(get_db())
+        # Open a connection to the database.
+        db = self.get()
 
-    # TODO: Add check to see if tables exists before creating.
-    # Create mod_logs table and columns to store moderator actions.
-    mod_logs = db.create_table("mod_logs")
-    mod_logs.create_column("user_id", db.types.bigint)
-    mod_logs.create_column("mod_id", db.types.bigint)
-    mod_logs.create_column("timestamp", db.types.bigint)
-    mod_logs.create_column("reason", db.types.text)
-    mod_logs.create_column("type", db.types.text)
+        # TODO: Add check to see if tables exists before creating.
+        # Create mod_logs table and columns to store moderator actions.
+        mod_logs = db.create_table("mod_logs")
+        mod_logs.create_column("user_id", db.types.bigint)
+        mod_logs.create_column("mod_id", db.types.bigint)
+        mod_logs.create_column("timestamp", db.types.bigint)
+        mod_logs.create_column("reason", db.types.text)
+        mod_logs.create_column("type", db.types.text)
 
-    # Create remind_me table and columns to store remind_me messages.
-    remind_me = db.create_table("remind_me")
-    remind_me.create_column("reminder_location", db.types.bigint)
-    remind_me.create_column("author_id", db.types.bigint)
-    remind_me.create_column("date_to_remind", db.types.bigint)
-    remind_me.create_column("message", db.types.text)
-    remind_me.create_column("sent", db.types.boolean, default=False)
+        # Create remind_me table and columns to store remind_me messages.
+        remind_me = db.create_table("remind_me")
+        remind_me.create_column("reminder_location", db.types.bigint)
+        remind_me.create_column("author_id", db.types.bigint)
+        remind_me.create_column("date_to_remind", db.types.bigint)
+        remind_me.create_column("message", db.types.text)
+        remind_me.create_column("sent", db.types.boolean, default=False)
 
-    # Create timed_mod_actions table and columns to store timed moderator actions.
-    timed_mod_actions = db.create_table("timed_mod_actions")
-    timed_mod_actions.create_column("user_id", db.types.bigint)
-    timed_mod_actions.create_column("mod_id", db.types.bigint)
-    timed_mod_actions.create_column("action_type", db.types.text)
-    timed_mod_actions.create_column("start_time", db.types.bigint)
-    timed_mod_actions.create_column("end_time", db.types.bigint)
-    timed_mod_actions.create_column("is_done", db.types.boolean, default=False)
-    timed_mod_actions.create_column("reason", db.types.text)
+        # Create timed_mod_actions table and columns to store timed moderator actions.
+        timed_mod_actions = db.create_table("timed_mod_actions")
+        timed_mod_actions.create_column("user_id", db.types.bigint)
+        timed_mod_actions.create_column("mod_id", db.types.bigint)
+        timed_mod_actions.create_column("action_type", db.types.text)
+        timed_mod_actions.create_column("start_time", db.types.bigint)
+        timed_mod_actions.create_column("end_time", db.types.bigint)
+        timed_mod_actions.create_column("is_done", db.types.boolean, default=False)
+        timed_mod_actions.create_column("reason", db.types.text)
 
-    # Create ticket table and columns to store the ticket status information
-    tickets = db.create_table("tickets")
-    tickets.create_column("user_id", db.types.bigint)
-    tickets.create_column("status", db.types.text)
-    tickets.create_column("guild", db.types.bigint)
-    tickets.create_column("timestamp", db.types.bigint)
-    tickets.create_column("ticket_topic", db.types.text)
-    tickets.create_column("log_url", db.types.text)
+        # Create ticket table and columns to store the ticket status information
+        tickets = db.create_table("tickets")
+        tickets.create_column("user_id", db.types.bigint)
+        tickets.create_column("status", db.types.text)
+        tickets.create_column("guild", db.types.bigint)
+        tickets.create_column("timestamp", db.types.bigint)
+        tickets.create_column("ticket_topic", db.types.text)
+        tickets.create_column("log_url", db.types.text)
 
-    # Create settings table and columns to store key:value pairs.
-    settings = db.create_table("settings")
-    settings.create_column("name", db.types.text)
-    settings.create_column("value", db.types.text)
-    settings.create_column("censored", db.types.boolean)
+        # Create settings table and columns to store key:value pairs.
+        settings = db.create_table("settings")
+        settings.create_column("name", db.types.text)
+        settings.create_column("value", db.types.text)
+        settings.create_column("censored", db.types.boolean)
 
-    # Commit the changes to the database and close the connection.
-    db.commit()
-    db.close()
+        # Commit the changes to the database and close the connection.
+        db.commit()
+        db.close()
 
-    # TODO: Retain what tables didn't exist/were created so we can print those to console.
-    log.info("Created any missing tables and columns.")
+        # TODO: Retain what tables didn't exist/were created so we can print those to console.
+        log.info("Created any missing tables and columns.")

--- a/utils/database.py
+++ b/utils/database.py
@@ -9,25 +9,20 @@ log = logging.getLogger(__name__)
 
 class Database:
     def __init__(self) -> None:
-        self.HOST = os.getenv("MYSQL_HOST")
-        self.DB = os.getenv("MYSQL_DATABASE")
-        self.USER = os.getenv("MYSQL_USER")
-        self.PASSWORD = os.getenv("MYSQL_PASSWORD")
-
-    def url(self) -> str:
-        """ Returns the database URL as a string. """
-        return f"mysql://{self.USER}:{self.PASSWORD}@{self.HOST}/{self.DB}"
+        self.host = os.getenv("MYSQL_HOST")
+        self.db = os.getenv("MYSQL_DATABASE")
+        self.user = os.getenv("MYSQL_USER")
+        self.password = os.getenv("MYSQL_PASSWORD")
+        self.url = f"mysql://{self.user}:{self.password}@{self.host}/{self.db}"
 
     def get(self) -> dataset.Database:
         """ Returns the dataset database object. """
-        return dataset.connect(
-            url=f"mysql://{self.USER}:{self.PASSWORD}@{self.HOST}/{self.DB}"
-        )
+        return dataset.connect(url=self.url)
 
     def setup(self) -> None:
         """ Sets up the tables needed for Chiya. """
         # Create the database if it doesn't already exist.
-        engine = create_engine(self.url())
+        engine = create_engine(self.url)
         if not database_exists(engine.url):
             create_database(engine.url)
 


### PR DESCRIPTION
The database class previously only returned the formatted URL string and not the object itself requiring us to import dataset in any file where a database operation was occurring which was redundant. 

get_db() was renamed to get() and now returns the Dataset database object. The new url() function has the same functionality as the old get_db() which is used for creating the database if it didn't already exist.