### PR TITLE
Fixed all instances where return was unnecessarily on a newline

### DIFF
--- a/cogs/commands/moderation/bans.py
+++ b/cogs/commands/moderation/bans.py
@@ -89,8 +89,7 @@ class BanCog(Cog):
         # Checks to see if the user is already banned.
         guild = self.bot.get_guild(guild)
         try:
-            await guild.fetch_ban(user)
-            return True
+            return await guild.fetch_ban(user)
         except discord.HTTPException:
             return False
 
@@ -169,22 +168,21 @@ class BanCog(Cog):
         member = await self.is_user_in_guild(guild=ctx.guild.id, user=user)
         if member:
             if not await can_action_member(bot=self.bot, ctx=ctx, member=member):
-                await embeds.error_message(ctx=ctx, description=f"You cannot action {member.mention}.")
-                return
+                return await embeds.error_message(ctx=ctx, description=f"You cannot action {member.mention}.")
+                
 
         # Checks if the user is already banned and let's the mod know if they already were.
         banned = await self.is_user_banned(guild=ctx.guild.id, user=user)
         if banned:
-            await embeds.error_message(ctx=ctx, description=f"{user.mention} is already banned.")
-            return
+            return await embeds.error_message(ctx=ctx, description=f"{user.mention} is already banned.")
 
         # Discord caps embed fields at a ridiculously low character limit, avoids problems with future embeds.
         if not reason:
             reason = "No reason provided."
         # Discord caps embed fields at a ridiculously low character limit, avoids problems with future embeds.
         elif len(reason) > 512:
-            await embeds.error_message(ctx=ctx, description="Reason must be less than 512 characters.")
-            return
+            return await embeds.error_message(ctx=ctx, description="Reason must be less than 512 characters.")
+
 
         # If the duration is not specified, default it to a permanent ban.
         if not duration:
@@ -205,15 +203,14 @@ class BanCog(Cog):
 
             # Bans the user and returns the embed letting the moderator know they were successfully banned.
             await self.ban_member(ctx=ctx, user=user, reason=reason, delete_message_days=daystodelete)
-            await ctx.send(embed=embed)
-            return
+            return await ctx.send(embed=embed)
+            
 
         # Get the duration string for embed and ban end time for the specified duration.
         duration_string, ban_end_time = utils.duration.get_duration(duration=duration)
         # If the duration string is empty due to Regex not matching anything, send and error embed and return.
         if not duration_string:
-            await embeds.error_message(ctx=ctx, description=f"Duration syntax: `#d#h#m#s` (day, hour, min, sec)\nYou can specify up to all four but you only need one.")
-            return
+            return await embeds.error_message(ctx=ctx, description=f"Duration syntax: `#d#h#m#s` (day, hour, min, sec)\nYou can specify up to all four but you only need one.")
 
         # Start creating the embed that will be used to alert the moderator that the user was successfully banned.
         embed = embeds.make_embed(
@@ -272,16 +269,14 @@ class BanCog(Cog):
         # Checks if the user is already banned and let's the mod know if they are not.
         banned = await self.is_user_banned(guild=ctx.guild.id, user=user)
         if not banned:
-            await embeds.error_message(ctx=ctx, description=f"{user.mention} is not banned.")
-            return
+            return await embeds.error_message(ctx=ctx, description=f"{user.mention} is not banned.")
 
         # Discord caps embed fields at a ridiculously low character limit, avoids problems with future embeds.
         if not reason:
             reason = "No reason provided."
         # Discord caps embed fields at a ridiculously low character limit, avoids problems with future embeds.
         elif len(reason) > 512:
-            await embeds.error_message(ctx=ctx, description="Reason must be less than 512 characters.")
-            return
+            return await embeds.error_message(ctx=ctx, description="Reason must be less than 512 characters.")
 
         # Creates and sends the embed that will be used to alert the moderator that the user was successfully banned.
         embed = embeds.make_embed(

--- a/cogs/commands/moderation/kicks.py
+++ b/cogs/commands/moderation/kicks.py
@@ -58,21 +58,18 @@ class KickCog(Cog):
 
         # If we received an int instead of a discord.Member, the user is not in the server.
         if not isinstance(member, discord.Member):
-            await embeds.error_message(ctx=ctx, description=f"That user is not in the server.")
-            return
-
+            return await embeds.error_message(ctx=ctx, description=f"That user is not in the server.")
+            
         # Checks if invoker can action that member (self, bot, etc.)
         if not await can_action_member(bot=self.bot, ctx=ctx, member=member):
-            await embeds.error_message(ctx=ctx, description=f"You cannot action {member.mention}.")
-            return
+            return await embeds.error_message(ctx=ctx, description=f"You cannot action {member.mention}.")
 
         # Discord caps embed fields at a ridiculously low character limit, avoids problems with future embeds.
         if not reason:
             reason = "No reason provided."
         # Discord caps embed fields at a ridiculously low character limit, avoids problems with future embeds.
         elif len(reason) > 512:
-            await embeds.error_message(ctx=ctx, description="Reason must be less than 512 characters.")
-            return
+            return await embeds.error_message(ctx=ctx, description="Reason must be less than 512 characters.")
 
         embed = embeds.make_embed(
             ctx=ctx,

--- a/cogs/commands/moderation/mutes.py
+++ b/cogs/commands/moderation/mutes.py
@@ -104,8 +104,7 @@ class MuteCog(Cog):
             embed.add_field(name="Mute Channel:", value=channel.mention, inline=True)
             embed.add_field(name="Reason:", value=reason, inline=False)
             embed.set_image(url="https://i.imgur.com/840Q48l.gif")
-            await dm_channel.send(embed=embed)
-            return True
+            return await dm_channel.send(embed=embed)
         except discord.HTTPException:
             return False
 
@@ -126,8 +125,7 @@ class MuteCog(Cog):
             embed.add_field(name="Moderator:", value=moderator.mention, inline=True)
             embed.add_field(name="Reason:", value=reason, inline=False)
             embed.set_image(url="https://i.imgur.com/U5Fvr2Y.gif")
-            await channel.send(embed=embed)
-            return True
+            return await channel.send(embed=embed)
         except discord.HTTPException:
             return False
 
@@ -166,8 +164,8 @@ class MuteCog(Cog):
             reason = "No reason provided."
         # Discord caps embed fields at a ridiculously low character limit, avoids problems with future embeds.
         elif len(reason) > 512:
-            await embeds.error_message(ctx=ctx, description="Reason must be less than 512 characters.")
-            return
+            return await embeds.error_message(ctx=ctx, description="Reason must be less than 512 characters.")
+            
 
         guild = guild or ctx.guild
         category = discord.utils.get(guild.categories, id=settings.get_value("category_tickets"))
@@ -321,26 +319,22 @@ class MuteCog(Cog):
 
         # If we received an int instead of a discord.Member, the user is not in the server.
         if not isinstance(member, discord.Member):
-            await embeds.error_message(ctx=ctx, description=f"That user is not in the server.")
-            return
+            return await embeds.error_message(ctx=ctx, description=f"That user is not in the server.")
 
         # Checks if invoker can action that member (self, bot, etc.)
         if not await can_action_member(bot=self.bot, ctx=ctx, member=member):
-            await embeds.error_message(ctx=ctx, description=f"You cannot action {member.mention}.")
-            return
+            return await embeds.error_message(ctx=ctx, description=f"You cannot action {member.mention}.")
 
         # Check if the user is muted already.
         if await self.is_user_muted(ctx=ctx, member=member):
-            await embeds.error_message(ctx=ctx, description=f"{member.mention} is already muted.")
-            return
+            return await embeds.error_message(ctx=ctx, description=f"{member.mention} is already muted.")
 
         # Automatically default the reason string to N/A when the moderator does not provide a reason.
         if not reason:
             reason = "No reason provided."
         # Discord caps embed fields at a ridiculously low character limit, avoids problems with future embeds.
         elif len(reason) > 512:
-            await embeds.error_message(ctx=ctx, description="Reason must be less than 512 characters.")
-            return
+            return await embeds.error_message(ctx=ctx, description="Reason must be less than 512 characters.")
 
         # If the duration is not specified, default it to a permanent mute.
         if not duration:
@@ -362,15 +356,14 @@ class MuteCog(Cog):
 
             # Mutes the user and returns the embed letting the moderator know they were successfully muted.
             await self.mute_member(ctx=ctx, member=member, reason=reason)
-            await ctx.send(embed=embed)
-            return
+            return await ctx.send(embed=embed)
+            
 
         # Get the duration string for embed and mute end time for the specified duration.
         duration_string, mute_end_time = utils.duration.get_duration(duration=duration)
         # If the duration string is empty due to Regex not matching anything, send and error embed and return.
         if not duration_string:
-            await embeds.error_message(ctx=ctx, description=f"Duration syntax: `#d#h#m#s` (day, hour, min, sec)\nYou can specify up to all four but you only need one.")
-            return
+            return await embeds.error_message(ctx=ctx, description=f"Duration syntax: `#d#h#m#s` (day, hour, min, sec)\nYou can specify up to all four but you only need one.")
 
         # Start creating the embed that will be used to alert the moderator that the user was successfully muted.
         embed = embeds.make_embed(
@@ -427,26 +420,22 @@ class MuteCog(Cog):
 
         # If we received an int instead of a discord.Member, the user is not in the server.
         if not isinstance(member, discord.Member):
-            await embeds.error_message(ctx=ctx, description=f"That user is not in the server.")
-            return
+            return await embeds.error_message(ctx=ctx, description=f"That user is not in the server.")
 
         # Checks if invoker can action that member (self, bot, etc.)
         if not await can_action_member(bot=self.bot, ctx=ctx, member=member):
-            await embeds.error_message(ctx=ctx, description=f"You cannot action {member.mention}.")
-            return
+            return await embeds.error_message(ctx=ctx, description=f"You cannot action {member.mention}.")
 
         # Check if the user is not muted already.
         if not await self.is_user_muted(ctx=ctx, member=member):
-            await embeds.error_message(ctx=ctx, description=f"{member.mention} is not muted.")
-            return
+            return await embeds.error_message(ctx=ctx, description=f"{member.mention} is not muted.")
 
         # Automatically default the reason string to N/A when the moderator does not provide a reason.
         if not reason:
             reason = "No reason provided."
         # Discord caps embed fields at a ridiculously low character limit, avoids problems with future embeds.
         elif len(reason) > 512:
-            await embeds.error_message(ctx=ctx, description="Reason must be less than 512 characters.")
-            return
+            return await embeds.error_message(ctx=ctx, description="Reason must be less than 512 characters.")
 
         # Start creating the embed that will be used to alert the moderator that the user was successfully unmuted.
         embed = embeds.make_embed(

--- a/cogs/commands/moderation/notes.py
+++ b/cogs/commands/moderation/notes.py
@@ -137,8 +137,8 @@ class NotesCog(Cog):
                     description=f"\"{action}\" is not a valid mod action filter. \n\nValid filters: ban, unban, mute, unmute, restrict, unrestrict, warn, kick, note"
                 )
                 # Close the connection.
-                db.close()
-                return
+                return db.close()
+                
         else:
             results = mod_logs.find(user_id=user.id)
 
@@ -175,8 +175,7 @@ class NotesCog(Cog):
 
         if not actions:
             # Nothing was found, so returning an appropriate error.
-            await embeds.error_message(ctx=ctx, description="No mod actions found for that user!")
-            return
+            return await embeds.error_message(ctx=ctx, description="No mod actions found for that user!") 
 
         page_no = 0
 
@@ -319,8 +318,7 @@ class NotesCog(Cog):
 
         mod_log = table.find_one(id=id)
         if not mod_log:
-            await embeds.error_message(ctx=ctx, description="Could not find a log with that ID!")
-            return
+            return await embeds.error_message(ctx=ctx, description="Could not find a log with that ID!")
 
         user = await self.bot.fetch_user(mod_log["user_id"])
         embed = embeds.make_embed(

--- a/cogs/commands/moderation/purge.py
+++ b/cogs/commands/moderation/purge.py
@@ -27,8 +27,7 @@ class PurgeCog(Cog):
 
         # Prevent mods from removing message in moderation categories
         if ctx.channel.category_id in [settings.get_value("category_moderation"), settings.get_value("category_development"), settings.get_value("category_logs"), settings.get_value("category_tickets")]:
-            await embeds.error_message(ctx=ctx, description="You cannot use that command in this category.")
-            return False
+            return await embeds.error_message(ctx=ctx, description="You cannot use that command in this category.")
 
         # Otherwise, the purge is fine to execute
         return True
@@ -71,8 +70,7 @@ class PurgeCog(Cog):
 
         # Limit the reason parameter to 512 characters.
         if reason and len(reason) > 512:
-            await embeds.error_message(ctx=ctx, description="Reason must be less than 512 characters.")
-            return
+            return await embeds.error_message(ctx=ctx, description="Reason must be less than 512 characters.")
 
         # Limit the command at 100 messages maximum to avoid abuse.
         amount = 100 if amount > 100 else amount

--- a/cogs/commands/moderation/restricts.py
+++ b/cogs/commands/moderation/restricts.py
@@ -107,8 +107,7 @@ class RestrictCog(Cog):
             embed.add_field(name="Length:", value=duration, inline=True)
             embed.add_field(name="Reason:", value=reason, inline=False)
             embed.set_image(url="https://i.imgur.com/NlXwNqW.gif")
-            await dm_channel.send(embed=embed)
-            return True
+            return await dm_channel.send(embed=embed)
         except discord.HTTPException:
             return False
 
@@ -129,8 +128,7 @@ class RestrictCog(Cog):
             embed.add_field(name="Moderator:", value=moderator.mention, inline=True)
             embed.add_field(name="Reason:", value=reason, inline=False)
             embed.set_image(url="https://i.imgur.com/rvvnpV2.gif")
-            await channel.send(embed=embed)
-            return True
+            return await channel.send(embed=embed)
         except discord.HTTPException:
             return False
 
@@ -174,26 +172,22 @@ class RestrictCog(Cog):
 
         # If we received an int instead of a discord.Member, the user is not in the server.
         if not isinstance(member, discord.Member):
-            await embeds.error_message(ctx=ctx, description=f"That user is not in the server.")
-            return
+            return await embeds.error_message(ctx=ctx, description=f"That user is not in the server.")
 
         # Checks if invoker can action that member (self, bot, etc.)
         if not await can_action_member(bot=self.bot, ctx=ctx, member=member):
-            await embeds.error_message(ctx=ctx, description=f"You cannot action {member.mention}.")
-            return
+            return await embeds.error_message(ctx=ctx, description=f"You cannot action {member.mention}.")
 
         # Check if the user is restricted already.
         if await self.is_user_restricted(ctx=ctx, member=member):
-            await embeds.error_message(ctx=ctx, description=f"{member.mention} is already restricted.")
-            return
+            return await embeds.error_message(ctx=ctx, description=f"{member.mention} is already restricted.")
 
         # Automatically default the reason string to N/A when the moderator does not provide a reason.
         if not reason:
             reason = "No reason provided."
         # Discord caps embed fields at a ridiculously low character limit, avoids problems with future embeds.
         elif len(reason) > 512:
-            await embeds.error_message(ctx=ctx, description="Reason must be less than 512 characters.")
-            return
+            return await embeds.error_message(ctx=ctx, description="Reason must be less than 512 characters.")
 
         # If duration is not specified, default it to a permanent restrict.
         if not duration:
@@ -212,15 +206,13 @@ class RestrictCog(Cog):
 
             # Restricts the user and returns the embed letting the moderator know they were successfully restricted.
             await self.restrict_member(ctx=ctx, member=member, reason=reason)
-            await ctx.send(embed=embed)
-            return
+            return await ctx.send(embed=embed)
 
         # Get the duration string for embed and restrict end time for the specified duration.
         duration_string, restrict_end_time = utils.duration.get_duration(duration=duration)
         # If the duration string is empty due to Regex not matching anything, send and error embed and return.
         if not duration_string:
-            await embeds.error_message(ctx=ctx, description=f"Duration syntax: `#d#h#m#s` (day, hour, min, sec)\nYou can specify up to all four but you only need one.")
-            return
+            return await embeds.error_message(ctx=ctx, description=f"Duration syntax: `#d#h#m#s` (day, hour, min, sec)\nYou can specify up to all four but you only need one.")
 
         # Start creating the embed that will be used to alert the moderator that the user was successfully restricted.
         embed = embeds.make_embed(
@@ -274,26 +266,22 @@ class RestrictCog(Cog):
 
         # If we received an int instead of a discord.Member, the user is not in the server.
         if not isinstance(member, discord.Member):
-            await embeds.error_message(ctx=ctx, description=f"That user is not in the server.")
-            return
+            return await embeds.error_message(ctx=ctx, description=f"That user is not in the server.")
 
         # Checks if invoker can action that member (self, bot, etc.)
         if not await can_action_member(bot=self.bot, ctx=ctx, member=member):
-            await embeds.error_message(ctx=ctx, description=f"You cannot action {member.mention}.")
-            return
+            return await embeds.error_message(ctx=ctx, description=f"You cannot action {member.mention}.")
 
         # Check if the user is not restricted already.
         if not await self.is_user_restricted(ctx=ctx, member=member):
-            await embeds.error_message(ctx=ctx, description=f"{member.mention} is not restricted.")
-            return
+            return await embeds.error_message(ctx=ctx, description=f"{member.mention} is not restricted.")
 
         # Automatically default the reason string to N/A when the moderator does not provide a reason.
         if not reason:
             reason = "No reason provided."
         # Discord caps embed fields at a ridiculously low character limit, avoids problems with future embeds.
         elif len(reason) > 512:
-            await embeds.error_message(ctx=ctx, description="Reason must be less than 512 characters.")
-            return
+            return await embeds.error_message(ctx=ctx, description="Reason must be less than 512 characters.") 
 
         # Start creating the embed that will be used to alert the moderator that the user was successfully unrestricted.
         embed = embeds.make_embed(

--- a/cogs/commands/moderation/tickets.py
+++ b/cogs/commands/moderation/tickets.py
@@ -57,9 +57,8 @@ class TicketCog(Cog):
 
         # Throw an error and return if we found an already existing ticket.
         if ticket:
-            await ctx.send(f"You already have a ticket open! {ticket.mention}", hidden=True)
             logging.info(f"{ctx.author} tried to create a new ticket but already had one open: {ticket}")
-            return
+            return await ctx.send(f"You already have a ticket open! {ticket.mention}", hidden=True)
 
         # Give both the staff and the user perms to access the channel.
         permissions = {

--- a/cogs/commands/moderation/warns.py
+++ b/cogs/commands/moderation/warns.py
@@ -57,12 +57,10 @@ class WarnsCog(Cog):
 
         # If we received an int instead of a discord.Member, the user is not in the server.
         if not isinstance(member, discord.Member):
-            await embeds.error_message(ctx=ctx, description=f"That user is not in the server.")
-            return
+            return await embeds.error_message(ctx=ctx, description=f"That user is not in the server.")
 
         if len(reason) > 512:
-            await embeds.error_message(ctx=ctx, description="Reason must be less than 512 characters.")
-            return
+            return await embeds.error_message(ctx=ctx, description="Reason must be less than 512 characters.")
 
         embed = embeds.make_embed(
             ctx=ctx,

--- a/cogs/commands/reminder.py
+++ b/cogs/commands/reminder.py
@@ -50,8 +50,8 @@ class Reminder(Cog):
         duration_string, end_time = utils.duration.get_duration(duration=duration)
         # If the duration string is empty due to Regex not matching anything, send and error embed and return.
         if not duration_string:
-            await embeds.error_message(ctx=ctx, description=f"Duration syntax: `#d#h#m#s` (day, hour, min, sec)\nYou can specify up to all four but you only need one.")
-            return
+            return await embeds.error_message(ctx=ctx, description=f"Duration syntax: `#d#h#m#s` (day, hour, min, sec)\nYou can specify up to all four but you only need one.")
+            
 
         # Open a connection to the database.
         db = database.Database().get()
@@ -111,13 +111,11 @@ class Reminder(Cog):
         old_message = reminder["message"]
 
         if reminder["author_id"] != ctx.author.id:
-            await embeds.error_message(ctx, "That reminder isn't yours, so you can't edit it.")
-            return
-
+            return await embeds.error_message(ctx, "That reminder isn't yours, so you can't edit it.")
+            
         if reminder["sent"]:
-            await embeds.error_message(ctx, "That reminder doesn't exist.")
-            return
-
+            return await embeds.error_message(ctx, "That reminder doesn't exist.")
+            
         data = dict(id=reminder["id"], message=new_message)
         remind_me.update(data, ["id"])
 
@@ -205,16 +203,13 @@ class Reminder(Cog):
         reminder = table.find_one(id=reminder_id)
 
         if not reminder:
-            await embeds.error_message(ctx=ctx, description="Invalid ID.")
-            return
+            return await embeds.error_message(ctx=ctx, description="Invalid ID.")
 
         if reminder["author_id"] != ctx.author.id:
-            await embeds.error_message(ctx=ctx, description="This reminder is not yours.")
-            return
+            return await embeds.error_message(ctx=ctx, description="This reminder is not yours.")
 
         if reminder["sent"]:
-            await embeds.error_message(ctx=ctx, description="This reminder has already been deleted.")
-            return
+            return await embeds.error_message(ctx=ctx, description="This reminder has already been deleted.")
 
         # All the checks should be done.
         data = dict(id=reminder_id, sent=True)

--- a/cogs/commands/settings.py
+++ b/cogs/commands/settings.py
@@ -76,9 +76,8 @@ class Settings(Cog):
         # Error if a setting already exists with that name.
         if result:
             embed = embeds.make_embed(description="A setting with that name already exists.", color="soft_red")
-            await ctx.send(embed=embed)
-            return
-
+            return await ctx.send(embed=embed)
+            
         # Add the setting to the database.
         table.insert(dict(
             name=name,
@@ -142,8 +141,7 @@ class Settings(Cog):
         # Error if a setting does not exist with that name.
         if not result:
             embed = embeds.make_embed(description="A setting with that name does not exist.", color="soft_red")
-            await ctx.send(embed=embed)
-            return
+            return await ctx.send(embed=embed)
 
         # Update the value(s) in the database.
         result["value"] = value
@@ -190,8 +188,7 @@ class Settings(Cog):
         # Error if a setting does not exist with that name.
         if not result:
             embed = embeds.make_embed(description="A setting with that name does not exist.", color="soft_red")
-            await ctx.send(embed=embed)
-            return
+            return await ctx.send(embed=embed)
 
         # Delete the setting from the database.
         table.delete(name=name)
@@ -228,8 +225,7 @@ class Settings(Cog):
         # Error if the list is empty because it means the table is empty.
         if not names:
             embed = embeds.make_embed(description="Unable to find any settings in the database.", color="soft_red")
-            await ctx.send(embed=embed)
-            return
+            return await ctx.send(embed=embed)
 
         # Format the list entries into inline codeblocks for the embed.
         names = f", ".join(f'`{name}`' for name in names)
@@ -270,8 +266,7 @@ class Settings(Cog):
         # Error if a setting does not exist with that name.
         if not result:
             embed = embeds.make_embed(description="A setting with that name does not exist.", color="soft_red")
-            await ctx.send(embed=embed)
-            return
+            return await ctx.send(embed=embed)
 
         # If the value is set to censored in the database, censor all but the first and last characters.
         if result.get("censored"):

--- a/cogs/listeners/error_handle.py
+++ b/cogs/listeners/error_handle.py
@@ -71,8 +71,7 @@ class error_handle(Cog):
 
         # Checking if error hasn't already been handled locally
         if hasattr(error, "handled"):
-            log.trace(f"Command {command} had its error already handled locally; ignoring.")
-            return
+            return log.trace(f"Command {command} had its error already handled locally; ignoring.")
 
         # Going through diffrent types of errors to handle them differently.
         if isinstance(error, errors.CommandNotFound) and not hasattr(ctx, "invoked_from_error_handler"):

--- a/cogs/tasks/reddit.py
+++ b/cogs/tasks/reddit.py
@@ -23,13 +23,12 @@ class RedditTask(commands.Cog):
 
         # Only define the object if all the env variable prerequisites exist.
         if not all([self.client_id, self.client_secret, self.user_agent]):
-            log.warning("Reddit functionality is disabled due to missing prerequisites")
-            return
+            return log.warning("Reddit functionality is disabled due to missing prerequisites")
+            
 
         # Only start the task if the needed prerequisites exist in the settings database.
         if not all([settings.get_value("subreddit"), settings.get_value("channel_reddit"), settings.get_value("poll_rate")]):
-            log.warning("Reddit functionality is disabled due to missing prerequisites")
-            return
+            return log.warning("Reddit functionality is disabled due to missing prerequisites")
 
         self.reddit = asyncpraw.Reddit(
             client_id=self.client_id,

--- a/cogs/tasks/reminders.py
+++ b/cogs/tasks/reminders.py
@@ -37,8 +37,7 @@ class ReminderTask(Cog):
 
         # If no results are found, simply terminate the db connection and return.
         if not result:
-            db.close()
-            return
+            return db.close()
 
         # Iterate over all the results found from the DB query if a result is found.
         for reminder in result:

--- a/cogs/tasks/timed_mod_actions.py
+++ b/cogs/tasks/timed_mod_actions.py
@@ -64,9 +64,8 @@ class TimedModActionsTask(Cog):
                     embed.description = f"Unmuted {user.mention} because their mute time elapsed but they have since left the server."
 
                     # Archives the mute channel, sends the embed in the moderation channel, and ends the function.
-                    await channel.send(embed=embed)
                     await mutes.archive_mute_channel(user_id=user.id, guild=guild, reason="Mute time elapsed.")
-                    return
+                    return await channel.send(embed=embed)
 
                 # Start creating the embed that will be used to alert the moderator that the user was successfully muted.
                 embed = embeds.make_embed(
@@ -128,8 +127,7 @@ class TimedModActionsTask(Cog):
                         color="soft_orange"
                     )
 
-                    await channel.send(embed=embed)
-                    return
+                    return await channel.send(embed=embed)
 
                 # Otherwise, create and send an embed to alert the moderator that the user was unrestricted.
                 embed = embeds.make_embed(


### PR DESCRIPTION
There were a lot of instances where we would unnecessarily returning on a separate line when we could just the result or the return the function call execution instead. This PR fixes all of those.