### PR TITLE
Mute log hotfix

### DIFF
--- a/cogs/commands/mutes.py
+++ b/cogs/commands/mutes.py
@@ -195,7 +195,7 @@ class MuteCog(Cog):
 
         # TODO: Implement so it gets the channel when the moderator is the bot
         # Loop through all messages in the ticket from old to new.
-        async for message in mute_channel.history(oldest_first=True):
+        async for message in mute_channel.history(oldest_first=True, limit=None):
             # Ignore the bot replies.
             if not message.author.bot:
                 # Pretty print the time tag into a more digestible format.

--- a/cogs/commands/tickets.py
+++ b/cogs/commands/tickets.py
@@ -160,7 +160,7 @@ class TicketCog(Cog):
         role_trial_mod = discord.utils.get(ctx.guild.roles, id=config["roles"]["trial_mod"])
 
         # Loop through all messages in the ticket from old to new.
-        async for message in ctx.channel.history(oldest_first=True):
+        async for message in ctx.channel.history(oldest_first=True, limit=None):
             # Ignore the bot replies.
             if not message.author.bot:
                 # Pretty print the time tag into a more digestible format.


### PR DESCRIPTION
Fixed mute and ticket channel log on privatebin can only contain up to 99 messages.